### PR TITLE
Use the pseudo-fd 0 as KsArray indice.

### DIFF
--- a/src/ksocket/berkeley.c
+++ b/src/ksocket/berkeley.c
@@ -7,8 +7,8 @@
 
 #define MEMORY_TAG            ' bsK'
 #define SOCKETFD_MAX          128
-#define TO_SOCKETFD(index)    ((index % SOCKETFD_MAX)  + 1)
-#define FROM_SOCKETFD(sockfd) ((sockfd)                - 1)
+#define TO_SOCKETFD(index)    ((index % SOCKETFD_MAX))
+#define FROM_SOCKETFD(sockfd) ((sockfd)              )
 
 //////////////////////////////////////////////////////////////////////////
 // Function prototypes.


### PR DESCRIPTION
 * On Unix/Linux the file descriptor 0 is valid and there is no need to waste the first indice.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>